### PR TITLE
Fix movement when logo loads + fix wrapper width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -246,8 +246,7 @@ pre code {
 .wrapper {
     margin-right: auto;
     margin-left: auto;
-    padding-right: var(--spacing-unit);
-    padding-left: var(--spacing-unit);
+    padding: var(--spacing-unit) var(--spacing-unit);
 }
 
 @media all and (max-width: var(--on-laptop)) {

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -60,6 +60,7 @@ button.navbar-toggle {
     margin-right: 23px;
     float: left;
     color: #e29fa0;
+    min-width: 260px;
 }
 
 .site-title:visited {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,9 +8,9 @@ class Header extends Component {
   render() {
     return (
       <header>
-        <div className="wrapper container">
+        <div className="container">
           <a className="site-title" href="/">
-            <img src="/activate.png" alt="Logo" className="brand" />
+            <img src="/activate.png" alt="" className="brand" />
           </a>
 
           <button className="navbar-toggle collapsed"


### PR DESCRIPTION
Fixes:
* There was movement in the header once the image was loaded, with this PR we will have a predefined size already and won't shift content around when the logo loads
* The wrapper for the content now has some padding so not everything is stuck on the sides