### PR TITLE
Better font loading (fixes #14)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
 
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans|Zilla+Slab|Zilla+Slab+Highlight" rel="stylesheet">
+    <link rel="stylesheet preload" href="https://fonts.googleapis.com/css?family=Open+Sans|Zilla+Slab|Zilla+Slab+Highlight">
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/src/App.css
+++ b/src/App.css
@@ -146,7 +146,7 @@ li {
  */
 
 h1 {
-    font-family: 'Zilla Slab Highlight', cursive;
+    font-family: 'Zilla Slab Highlight', sans-serif;
     font-weight: 400;
 }
 


### PR DESCRIPTION
Before:

<img width="1231" alt="screen shot 2018-07-11 at 19 47 24" src="https://user-images.githubusercontent.com/330324/42590375-ec1475d6-8543-11e8-9012-119e661c578f.png">

After:

<img width="1280" alt="screen shot 2018-07-11 at 19 53 39" src="https://user-images.githubusercontent.com/330324/42590450-21eb3ff0-8544-11e8-98ec-acb639aafbb2.png">


The "preload" makes sure that the font gets loaded as soon as it can, not only after the browser decides that it's actually gonna be needed. This brings down the loading time by 50% locally here. Together with the sans-serif the flashing is less. It's still there but way less. So I think this is ok for now.